### PR TITLE
Fix ConfigParser on py3, fix port/dbid not being cast

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,5 +6,6 @@ verify_ssl = true
 docker-compose = "*"
 
 [packages]
+six = "*"
 txredisapi = "*"
 Twisted = "*"

--- a/ddns.tac
+++ b/ddns.tac
@@ -1,14 +1,14 @@
 import txredisapi
 from twisted.application import service, internet
 from twisted.names import dns
-from ConfigParser import ConfigParser
+from six.moves.configparser import ConfigParser
 
 from ddns.protocol import DDNSFactory
 
 
 def create_application():
     _application = service.Application('ddns')
-    _collection = service.IServiceCollection(application)
+    _collection = service.IServiceCollection(_application)
 
     config = ConfigParser()
     config.read('ddns.ini')
@@ -17,8 +17,8 @@ def create_application():
 
     redis_client = txredisapi.lazyConnectionPool(
         host=config.get('redis', 'host'),
-        port=config.get('redis', 'port'),
-        dbid=config.get('redis', 'db')
+        port=int(config.get('redis', 'port')),
+        dbid=int(config.get('redis', 'db'))
     )
 
     ddns_factory = DDNSFactory(redis_client)


### PR DESCRIPTION
Fixes a few issues in ddns.tac.
I used this as a base for spawning the application and noticed some issues.

* `ConfigParser` module is lowercase in Py3. Used six to support both.
* `application` doesnt exist and should be `_application`
* config values must be cast to int (as is done in `ddns_plugin.py`) or an error results

I added six to Pipfile, but not Pipfile.lock as I don't use these format files.